### PR TITLE
Add (better) instructions on how to install these dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # Dotfiles
 
 To Install: 
-```
+```bash
+# Install HomeBrew
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+
+# Pull and Install Dotfiles
 git --work-tree=$HOME --git-dir=$HOME/.files.git init && \
 git --work-tree=$HOME --git-dir=$HOME/.files.git remote add origin https://github.com/DanToml/Dotfiles.git && \
 git --work-tree=$HOME --git-dir=$HOME/.files.git pull origin master && \


### PR DESCRIPTION
I added a little better instructions on how to install the dotfiles. It wasn't immediately obvious that I needed Brew off the bat to install these. 
